### PR TITLE
Fix bug that leads to 404 page

### DIFF
--- a/classes/chronosly_templates.php
+++ b/classes/chronosly_templates.php
@@ -807,7 +807,7 @@ if(!class_exists('Chronosly_Templates')){
                             //echo date("Y-m-d",$v)." ".$v;
                             $this->vars->metas['repeat'] = $v;
                             if(substr($this->vars->link, -1) != "/") $this->vars->link .="/";
-                            $this->vars->link .= (get_option('permalink_structure')?"repeat_$v":"&repeat=$v");
+                            $this->vars->link .= (get_option('permalink_structure')?"?repeat_$v":"&repeat=$v");
                             break;
                         case "end":
                             $this->vars->metas['ev-to'][0] = date("Y-m-d",$v);


### PR DESCRIPTION
Fixing possible bug with link that leads to 404 page
http://sirwilliam.org/en/events/evangelization/repeat_1484438400_1484438400
changed to
http://sirwilliam.org/en/events/evangelization/?repeat_1484438400_1484438400

I am not sure if this is the right fix, but the link works and I don't have a 404 page anymore